### PR TITLE
Use mkmf to check for preexisting installation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 Gemfile.lock
 pkg/*
 chromedriver.log
+mkmf.log

--- a/lib/chromedriver/helper.rb
+++ b/lib/chromedriver/helper.rb
@@ -12,6 +12,7 @@ module Chromedriver
     end
 
     def download hit_network=false
+      return if preexisting_installation
       return if File.exists?(binary_path) && ! hit_network
       url = download_url
       filename = File.basename url
@@ -33,11 +34,17 @@ module Chromedriver
     end
 
     def binary_path
+      return preexisting_installation if preexisting_installation
       if platform == "win"
         File.join platform_install_dir, "chromedriver.exe"
       else
         File.join platform_install_dir, "chromedriver"
       end
+    end
+
+    def preexisting_installation
+      require 'mkmf'
+      find_executable 'chromedriver'
     end
 
     def platform_install_dir

--- a/spec/helper_spec.rb
+++ b/spec/helper_spec.rb
@@ -4,13 +4,24 @@ describe Chromedriver::Helper do
   let(:helper) { Chromedriver::Helper.new }
 
   describe "#binary_path" do
+    context "preexisting installation" do
+      before { allow(helper).to receive(:preexisting_installation) { "/usr/local/bin/chromedriver" } }
+      it { expect(helper.binary_path).to match(/chromedriver$/) }
+    end
+
     context "on a linux platform" do
-      before { allow(helper).to receive(:platform) { "linux32" } }
+      before do
+        allow(helper).to receive(:preexisting_installation).and_return(nil)
+        allow(helper).to receive(:platform) { "linux32" }
+      end
       it { expect(helper.binary_path).to match(/chromedriver$/) }
     end
 
     context "on a windows platform" do
-      before { allow(helper).to receive(:platform) { "win" } }
+      before do
+        allow(helper).to receive(:preexisting_installation).and_return(nil)
+        allow(helper).to receive(:platform) { "win" }
+      end
       it { expect(helper.binary_path).to match(/chromedriver\.exe$/) }
     end
   end


### PR DESCRIPTION
And added/updated unit tests. Based on http://stackoverflow.com/a/19938871

I love this gem! But it doesn't work on Travis CI and breaks preexisting installations (i.e. chromedriver installed through brew).

Let me know if this is the correct approach, I'll be happy to update it if not.

One use case that I'm not sure how to handle is:
1) User already has a preexisting, but old chromedriver installation.
2) They would like to use `chromedriver-update` to update it but it doesn't work ([premature return on line 15](https://github.com/flavorjones/chromedriver-helper/pull/16/files#diff-1a829951164c71fab87971690c2c0d5eR15))

Perhaps I can write to stderr indicating that the user should uninstall the preexisting chromedriver in order to use `chromedriver-update`?

And another thing, mkmf prints to stdout and creates a mkmf.log file. I can make both disappear by doing something like http://stackoverflow.com/a/26511639