### PR TITLE
remove dependency on the version_sorter gem; this gem does not work in JRuby

### DIFF
--- a/chromedriver-helper.gemspec
+++ b/chromedriver-helper.gemspec
@@ -19,5 +19,4 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rspec",      "~> 3.0"
   s.add_development_dependency "rake"
   s.add_runtime_dependency "nokogiri",       "~> 1.6"
-  s.add_runtime_dependency "version_sorter", "~> 1.1"
 end

--- a/lib/chromedriver/helper/google_code_parser.rb
+++ b/lib/chromedriver/helper/google_code_parser.rb
@@ -1,6 +1,5 @@
 require 'nokogiri'
 require 'open-uri'
-require 'version_sorter'
 
 module Chromedriver
   class Helper
@@ -22,7 +21,14 @@ module Chromedriver
       end
 
       def newest_download
-        VersionSorter.sort(downloads).last
+        (downloads.sort { |a, b| version_of(a) <=> version_of(b)}).last
+      end
+
+      private
+
+      def version_of(url)
+        v = url.gsub("#{BUCKET_URL}/", "").split("/").shift
+        Gem::Version.new(v)
       end
     end
   end


### PR DESCRIPTION
The `version_sorter` gem builds a native extension, and thus won't work in JRuby. Sort using `Gem::Version` comparator instead of `VersionSorter` to make this compatible across rubies.