### PR TITLE
fix for chromedriver update on windows

### DIFF
--- a/chromedriver-helper.gemspec
+++ b/chromedriver-helper.gemspec
@@ -20,4 +20,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rake"
   s.add_runtime_dependency "nokogiri",       "~> 1.6"
   s.add_runtime_dependency "version_sorter", "~> 1.1"
+  s.add_runtime_dependency "archive-zip",   "~> 0.7.0"
 end

--- a/lib/chromedriver/helper.rb
+++ b/lib/chromedriver/helper.rb
@@ -2,6 +2,8 @@ require "chromedriver/helper/version"
 require "chromedriver/helper/google_code_parser"
 require 'fileutils'
 require 'rbconfig'
+require 'open-uri'
+require 'archive/zip'
 
 module Chromedriver
   class Helper
@@ -16,10 +18,14 @@ module Chromedriver
       url = download_url
       filename = File.basename url
       Dir.chdir platform_install_dir do
-        system "rm #{filename}"
-        system("wget -c -O #{filename} #{url}") || system("curl -C - -o #{filename} #{url}")
+        File.delete(filename) if File.exists? filename
+		File.open(filename, "wb") do |saved_file|
+			URI.parse(url).open("rb") do |read_file|
+				saved_file.write(read_file.read)
+			end
+		end
         raise "Could not download #{url}" unless File.exists? filename
-        system "unzip -o #{filename}"
+        Archive::Zip.extract(filename, '.')
       end
       raise "Could not unzip #{filename} to get #{binary_path}" unless File.exists? binary_path
     end


### PR DESCRIPTION
As written, Chromedriver::Helper#download presumes unzip, rm, and wget or curl in the system path. This PR converts to ruby-native code, and makes this gem work out of the box on windows. 