### PR TITLE
Add nokogiri 1.7 to supported versions

### DIFF
--- a/chromedriver-helper.gemspec
+++ b/chromedriver-helper.gemspec
@@ -29,6 +29,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rake",      "~> 10.0"
   s.add_development_dependency "concourse", "~> 0.12"
 
-  s.add_runtime_dependency "nokogiri",      "~> 1.6"
+  s.add_runtime_dependency "nokogiri",      ">= 1.6", "< 1.8"
   s.add_runtime_dependency "archive-zip",   "~> 0.7.0"
 end


### PR DESCRIPTION
Nokogiri 1.7.1 contains a security bugfix and chromedriver-helper's dependency on 1.6 was preventing me from upgrading. 1.7 is mostly a bugfix release so I guess it shouldn't break anything.
https://github.com/sparklemotion/nokogiri/blob/master/CHANGELOG.md#171--2017-03-19