### PR TITLE
Use https for the BUCKET_URL instead of http.

### DIFF
--- a/lib/chromedriver/helper/google_code_parser.rb
+++ b/lib/chromedriver/helper/google_code_parser.rb
@@ -4,7 +4,7 @@ require 'open-uri'
 module Chromedriver
   class Helper
     class GoogleCodeParser
-      BUCKET_URL = 'http://chromedriver.storage.googleapis.com'
+      BUCKET_URL = 'https://chromedriver.storage.googleapis.com'
 
       attr_reader :source, :platform
 

--- a/spec/google_code_parser_spec.rb
+++ b/spec/google_code_parser_spec.rb
@@ -11,11 +11,11 @@ describe Chromedriver::Helper::GoogleCodeParser do
   describe "#downloads" do
     it "returns an array of URLs for the platform" do
       expect(parser.downloads).to eq [
-        "http://chromedriver.storage.googleapis.com/2.0/chromedriver_mac32.zip",
-        "http://chromedriver.storage.googleapis.com/2.1/chromedriver_mac32.zip",
-        "http://chromedriver.storage.googleapis.com/2.2/chromedriver_mac32.zip",
-        "http://chromedriver.storage.googleapis.com/2.3/chromedriver_mac32.zip",
-        "http://chromedriver.storage.googleapis.com/2.4/chromedriver_mac32.zip"]
+        "https://chromedriver.storage.googleapis.com/2.0/chromedriver_mac32.zip",
+        "https://chromedriver.storage.googleapis.com/2.1/chromedriver_mac32.zip",
+        "https://chromedriver.storage.googleapis.com/2.2/chromedriver_mac32.zip",
+        "https://chromedriver.storage.googleapis.com/2.3/chromedriver_mac32.zip",
+        "https://chromedriver.storage.googleapis.com/2.4/chromedriver_mac32.zip"]
     end
   end
 
@@ -27,10 +27,10 @@ describe Chromedriver::Helper::GoogleCodeParser do
     context "out-of-order versions" do
       before do
         allow(parser).to receive(:downloads).and_return([
-          "http://chromedriver.storage.googleapis.com/2.3/chromedriver_mac32.zip",
-          "http://chromedriver.storage.googleapis.com/2.4/chromedriver_mac32.zip",
-          "http://chromedriver.storage.googleapis.com/2.14/chromedriver_mac32.zip",
-          "http://chromedriver.storage.googleapis.com/2.2/chromedriver_mac32.zip",
+          "https://chromedriver.storage.googleapis.com/2.3/chromedriver_mac32.zip",
+          "https://chromedriver.storage.googleapis.com/2.4/chromedriver_mac32.zip",
+          "https://chromedriver.storage.googleapis.com/2.14/chromedriver_mac32.zip",
+          "https://chromedriver.storage.googleapis.com/2.2/chromedriver_mac32.zip",
         ])
       end
 
@@ -42,7 +42,7 @@ describe Chromedriver::Helper::GoogleCodeParser do
 
   describe '#version_download_url' do
     it 'returns the version asked for' do
-      expect(parser.version_download_url(2.0)).to eq "http://chromedriver.storage.googleapis.com/2.0/chromedriver_mac32.zip"
+      expect(parser.version_download_url(2.0)).to eq "https://chromedriver.storage.googleapis.com/2.0/chromedriver_mac32.zip"
     end
   end
 end


### PR DESCRIPTION
Me and some others were having this issue:
```
$ chromedriver-update 
/Users/michaelchui/.rbenv/versions/2.3.3/lib/ruby/2.3.0/net/protocol.rb:158:in `rbuf_fill': Net::ReadTimeout (Net::ReadTimeout)
	from /Users/michaelchui/.rbenv/versions/2.3.3/lib/ruby/2.3.0/net/protocol.rb:106:in `read'
	from /Users/michaelchui/.rbenv/versions/2.3.3/lib/ruby/2.3.0/net/http/response.rb:291:in `block in read_body_0'
	from /Users/michaelchui/.rbenv/versions/2.3.3/lib/ruby/2.3.0/net/http/response.rb:276:in `inflater'
	from /Users/michaelchui/.rbenv/versions/2.3.3/lib/ruby/2.3.0/net/http/response.rb:281:in `read_body_0'
	from /Users/michaelchui/.rbenv/versions/2.3.3/lib/ruby/2.3.0/net/http/response.rb:202:in `read_body'
	from /Users/michaelchui/.rbenv/versions/2.3.3/lib/ruby/2.3.0/open-uri.rb:334:in `block (2 levels) in open_http'
	from /Users/michaelchui/.rbenv/versions/2.3.3/lib/ruby/2.3.0/net/http.rb:1446:in `block in transport_request'
	from /Users/michaelchui/.rbenv/versions/2.3.3/lib/ruby/2.3.0/net/http/response.rb:163:in `reading_body'
	from /Users/michaelchui/.rbenv/versions/2.3.3/lib/ruby/2.3.0/net/http.rb:1445:in `transport_request'
	from /Users/michaelchui/.rbenv/versions/2.3.3/lib/ruby/2.3.0/net/http.rb:1407:in `request'
	from /Users/michaelchui/.rbenv/versions/2.3.3/lib/ruby/2.3.0/open-uri.rb:325:in `block in open_http'
	from /Users/michaelchui/.rbenv/versions/2.3.3/lib/ruby/2.3.0/net/http.rb:853:in `start'
	from /Users/michaelchui/.rbenv/versions/2.3.3/lib/ruby/2.3.0/open-uri.rb:319:in `open_http'
	from /Users/michaelchui/.rbenv/versions/2.3.3/lib/ruby/2.3.0/open-uri.rb:737:in `buffer_open'
	from /Users/michaelchui/.rbenv/versions/2.3.3/lib/ruby/2.3.0/open-uri.rb:212:in `block in open_loop'
	from /Users/michaelchui/.rbenv/versions/2.3.3/lib/ruby/2.3.0/open-uri.rb:210:in `catch'
	from /Users/michaelchui/.rbenv/versions/2.3.3/lib/ruby/2.3.0/open-uri.rb:210:in `open_loop'
	from /Users/michaelchui/.rbenv/versions/2.3.3/lib/ruby/2.3.0/open-uri.rb:151:in `open_uri'
	from /Users/michaelchui/.rbenv/versions/2.3.3/lib/ruby/2.3.0/open-uri.rb:717:in `open'
	from /Users/michaelchui/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/chromedriver-helper-1.1.0/lib/chromedriver/helper.rb:28:in `block (2 levels) in download'
	from /Users/michaelchui/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/chromedriver-helper-1.1.0/lib/chromedriver/helper.rb:27:in `open'
	from /Users/michaelchui/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/chromedriver-helper-1.1.0/lib/chromedriver/helper.rb:27:in `block in download'
	from /Users/michaelchui/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/chromedriver-helper-1.1.0/lib/chromedriver/helper.rb:25:in `chdir'
	from /Users/michaelchui/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/chromedriver-helper-1.1.0/lib/chromedriver/helper.rb:25:in `download'
	from /Users/michaelchui/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/chromedriver-helper-1.1.0/lib/chromedriver/helper.rb:47:in `update'
	from /Users/michaelchui/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/chromedriver-helper-1.1.0/bin/chromedriver-update:5:in `<top (required)>'
	from /Users/michaelchui/.rbenv/versions/2.3.3/bin/chromedriver-update:22:in `load'
	from /Users/michaelchui/.rbenv/versions/2.3.3/bin/chromedriver-update:22:in `<main>'
	from /Users/michaelchui/.rbenv/versions/2.3.3/bin/ruby_executable_hooks:15:in `eval'
	from /Users/michaelchui/.rbenv/versions/2.3.3/bin/ruby_executable_hooks:15:in `<main>'
```

Directly downloading using `cUrl` or a browser failed similarly. However, when I navigated around chromedriver's website and found a [direct download link](https://chromedriver.storage.googleapis.com/index.html?path=2.29/), I noticed that it used `https` and made the following change.

It seemed to address it. I honestly don't know why; it seems to me that an SSL handshake ought to have failed outright instead of timing out at the end of the download.