### PR TITLE
Relax archive-zip gem version requirement

### DIFF
--- a/chromedriver-helper.gemspec
+++ b/chromedriver-helper.gemspec
@@ -30,5 +30,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency "concourse", "~> 0.12"
 
   s.add_runtime_dependency "nokogiri",      "~> 1.6"
-  s.add_runtime_dependency "archive-zip",   "~> 0.7.0"
+  s.add_runtime_dependency "archive-zip",   "~> 0.7"
 end


### PR DESCRIPTION
On Ruby `2.4.x` the `archive-zip` gem causes warnings:

```
/Users/oli/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/archive-zip-0.7.0/lib/archive/zip/entry.rb:935: warning: assigned but unused variable - raw_data
/Users/oli/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/archive-zip-0.7.0/lib/archive/zip/extra_field/unix.rb:137: warning: method redefined; discarding old dump_local
/Users/oli/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/archive-zip-0.7.0/lib/archive/zip/extra_field/unix.rb:127: warning: previous definition of dump_local was here
```

This has been fixed upstream (https://github.com/javanthropus/archive-zip/pull/14) and from version `0.8.0` upwards the warnings no longer occur.

I've tried running the specs against `0.9.0` and they pass on my machine. There haven't been any signification changes from [v0.7.0 to v0.9.0](https://github.com/javanthropus/archive-zip/compare/v0.7.0...v0.9.0).

---

I could extend the PR to use the [appraisal gem](https://github.com/thoughtbot/appraisal) so multiple versions of the runtime dependencies can be checked during tests. Please let me know if that's of interest!