### PR TITLE
Bumping Gem Spec Dependencies for Archive ZIP and Nokogiri

### DIFF
--- a/chromedriver-helper.gemspec
+++ b/chromedriver-helper.gemspec
@@ -29,6 +29,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rake",      "~> 10.0"
   s.add_development_dependency "concourse", "~> 0.12"
 
-  s.add_runtime_dependency "nokogiri",      "~> 1.6"
-  s.add_runtime_dependency "archive-zip",   "~> 0.7.0"
+  s.add_runtime_dependency "nokogiri",      "~> 1.8"
+  s.add_runtime_dependency "archive-zip",   "~> 0.10"
 end


### PR DESCRIPTION
The current version of archive ZIP (0.10.0) has a few stability fixes that using this gem prevents (since it is pinned to 0.7.0). This PR unpins and also bumps Nokogiri dependency (although not strictly pinned).