### PR TITLE
Make Helper#platform raise an exception on unknown OSs

### DIFF
--- a/lib/chromedriver/helper.rb
+++ b/lib/chromedriver/helper.rb
@@ -99,11 +99,17 @@ module Chromedriver
 
     def platform
       cfg = RbConfig::CONFIG
-      case cfg['host_os']
+      host_cpu = cfg["host_cpu"]
+      host_os = cfg["host_os"]
+
+      case host_os
       when /linux/ then
-        cfg['host_cpu'] =~ /x86_64|amd64/ ? "linux64" : "linux32"
+        host_cpu =~ /x86_64|amd64/ ? "linux64" : "linux32"
       when /darwin/ then "mac"
-      else "win"
+      when /mswin/ then "win"
+      when /mingw/ then "win"
+      else
+        raise("Unsupported host OS '#{host_os}'")
       end
     end
   end

--- a/spec/helper_spec.rb
+++ b/spec/helper_spec.rb
@@ -14,4 +14,43 @@ describe Chromedriver::Helper do
       it { expect(helper.binary_path).to match(/chromedriver\.exe$/) }
     end
   end
+
+  describe '#platform' do
+    os_cpu_matrix = [
+      { 'host_os' => 'darwin','host_cpu' => 'irrelevant', 'expected_platform' => 'mac' },
+      { 'host_os' => 'linux', 'host_cpu' => 'amd64',      'expected_platform' => 'linux64' },
+      { 'host_os' => 'linux', 'host_cpu' => 'irrelevant', 'expected_platform' => 'linux32' },
+      { 'host_os' => 'linux', 'host_cpu' => 'x86_64',     'expected_platform' => 'linux64' },
+      { 'host_os' => 'mingw', 'host_cpu' => 'irrelevant', 'expected_platform' => 'win' },
+      { 'host_os' => 'mswin', 'host_cpu' => 'irrelevant', 'expected_platform' => 'win' }
+    ]
+
+    os_cpu_matrix.each do |config|
+      expected_platform = config['expected_platform']
+      host_cpu          = config['host_cpu']
+      host_os           = config['host_os']
+
+      context "given host OS #{host_os} and host CPU #{host_cpu}" do
+        before do
+          RbConfig.send(:remove_const, :CONFIG)
+          RbConfig::CONFIG = { 'host_os' => host_os, 'host_cpu' => host_cpu }
+        end
+
+        it "returns #{expected_platform}" do
+          expect(helper.platform).to eq(expected_platform)
+        end
+      end
+    end
+
+    context 'given an unknown host OS' do
+      before do
+        RbConfig.send(:remove_const, :CONFIG)
+        RbConfig::CONFIG = { 'host_os' => 'freebsd', 'host_cpu' => 'irrelevant' }
+      end
+
+      it 'raises an exception' do
+        expect { helper.platform }.to raise_error("Unsupported host OS 'freebsd'")
+      end
+    end
+  end
 end


### PR DESCRIPTION
Currently, #platform returns 'win' if it can't figure out what OS Ruby
is running on.

This leads to it attempting to run the Windows binary for
Chromedriver, and thus odd errors on FreeBSD. See #49.

This change makes #platform raise an exception on unsupported OSs, to
make it clear what's going on.

FreeBSD support is a separate issue, which I will address if I have
the time.
  