### PR TITLE
Only ref Selenium if selenium-webdriver present

### DIFF
--- a/lib/chromedriver-helper.rb
+++ b/lib/chromedriver-helper.rb
@@ -1,1 +1,6 @@
-Selenium::WebDriver::Chrome.driver_path=Gem.bin_path("chromedriver-helper","chromedriver-helper")
+begin
+  require "selenium-webdriver"
+  Selenium::WebDriver::Chrome.driver_path=Gem.bin_path("chromedriver-helper","chromedriver-helper")
+rescue LoadError
+  # ignore
+end


### PR DESCRIPTION
Before, the code was accessing the `Selenium::WebDriver::Chrome` assuming that it had already been defined. There is no guarantee that this will be the case.

Fix by explicitly loading the `selenium-webdriver` gem first in order to define these constants. If the gem is not present, gracefully skip this code instead of crashing with "uninitialized constant".

Fixes #60